### PR TITLE
Fix multiple design flaws

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "printWidth": 120,
   "singleQuote": true,
   "jsxSingleQuote": true,
   "arrowParens": "always"

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ export default withError(ErrorPage)(MyApp);
 
 Work to automate this [is tracked here](https://github.com/martpie/next-with-error/issues/2).
 
-The error object is accessible via the `props.error` variable.
+The error object properties are accessible via the `props` of your custom Error component (`props.statusCode`, `props.message`, etc if you have custom props).
 
 ⚠️ If your custom Error page has a `getInitialProps` method, the error object will be merged in `getInitialProps`'s return value. Be careful to not have conflicting names.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ export default withError(ErrorPage)(MyApp);
 
 Work to automate this [is tracked here](https://github.com/martpie/next-with-error/issues/2).
 
+The error object is accessible via the `props.error` variable.
+
+⚠️ If your custom Error page has a `getInitialProps` method, the error object will be merged in `getInitialProps`'s return value. Be careful to not have conflicting names.
+
 ### Custom props
 
 You can also pass custom props to your Error Page component by adding anything you would like in the `error` object:
@@ -173,8 +177,8 @@ import React from 'react';
 const Error = (props) => {
   return (
     <>
-      <h1>Custom error page: {props.statusCode}</h1>
-      <p>{props.message}</p>
+      <h1>Custom error page: {props.error.statusCode}</h1>
+      <p>{props.error.message}</p>
     </>
   );
 };

--- a/README.md
+++ b/README.md
@@ -185,3 +185,5 @@ const Error = (props) => {
 
 export default Error;
 ```
+
+⚠️ Be careful to add default values for your custom props in the `Error` component, as Next.js routing may bypass `next-with-error`'s behavior by showing the 404 page without the `message` variable (in this example).

--- a/src/__tests__/__apps__/custom-error/pages/_app.jsx
+++ b/src/__tests__/__apps__/custom-error/pages/_app.jsx
@@ -14,6 +14,7 @@ class MyApp extends App {
 
   render() {
     const { Component, pageProps } = this.props;
+
     return <Component {...pageProps} />;
   }
 }

--- a/src/__tests__/__apps__/custom-error/pages/_error.jsx
+++ b/src/__tests__/__apps__/custom-error/pages/_error.jsx
@@ -3,17 +3,16 @@ import React from 'react';
 const Error = (props) => {
   return (
     <>
-      <h1>Custom error page: {props.error.statusCode}</h1>
-      <p>{props.error.message}</p>
+      <h1>Custom error page: {props.statusCode}</h1>
+      <p>{props.message}</p>
       <h2>Additional prop: {props.additional}</h2>
     </>
   );
 };
 
-Error.getInitialProps = () => {
-  return {
-    additional: 42
-  };
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode, additional: 42 };
 };
 
 export default Error;

--- a/src/__tests__/__apps__/custom-error/pages/_error.jsx
+++ b/src/__tests__/__apps__/custom-error/pages/_error.jsx
@@ -3,10 +3,17 @@ import React from 'react';
 const Error = (props) => {
   return (
     <>
-      <h1>Custom error page: {props.statusCode}</h1>
-      <p>{props.message}</p>
+      <h1>Custom error page: {props.error.statusCode}</h1>
+      <p>{props.error.message}</p>
+      <h2>Additional prop: {props.additional}</h2>
     </>
   );
+};
+
+Error.getInitialProps = () => {
+  return {
+    additional: 42
+  };
 };
 
 export default Error;

--- a/src/__tests__/e2e/custom-error.test.ts
+++ b/src/__tests__/e2e/custom-error.test.ts
@@ -42,4 +42,16 @@ describe('custom-error end-to-end test', () => {
     const content = await page.$eval('p', (e) => e.textContent);
     expect(content).toBe('something went wrong');
   });
+
+  test("custom error componen's getInitialProps should be correctly called and its result merged with the error object", async () => {
+    const page = await browser.newPage();
+    const response = await page.goto(`${BASE_URL}/posts/crash-me`);
+
+    if (!response) throw new Error('Could not access the page');
+
+    expect(response.status()).toBe(500);
+
+    const content = await page.$eval('h2', (e) => e.textContent);
+    expect(content).toBe('Additional prop: 42');
+  });
 });

--- a/src/next-with-error.tsx
+++ b/src/next-with-error.tsx
@@ -109,11 +109,18 @@ const withErrorHoC = function(ErrorComponent = ErrorPage) {
         const { error } = pageProps;
 
         if (error && error.statusCode >= 400) {
+          const { error, ...otherPageProps } = pageProps;
+
+          const errorPageProps = {
+            ...otherPageProps,
+            ...error
+          };
+
           return (
             <AppComponent
               {...this.props}
               Component={ErrorComponent}
-              pageProps={pageProps}
+              pageProps={errorPageProps}
             />
           );
         }

--- a/src/next-with-error.tsx
+++ b/src/next-with-error.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
-import { default as NextApp, AppContext, AppProps } from 'next/app';
+import {
+  default as NextApp,
+  AppContext,
+  AppProps,
+  AppInitialProps
+} from 'next/app';
+import { NextComponentType, NextPageContext } from 'next';
 
-const ErrorPage = dynamic(() => import('next/error'));
+// FIXME It looks like typings for next/error are wrong
+const ErrorPage = dynamic(() => import('next/error')) as NextComponentType<
+  NextPageContext,
+  {},
+  {}
+>;
 
 export interface PageErrorInitialProps<T = Record<string, any>> {
   error?: {
@@ -10,11 +21,10 @@ export interface PageErrorInitialProps<T = Record<string, any>> {
   } & T;
 }
 
-export type ExcludeErrorProps<P> = Pick<P, Exclude<keyof P, keyof PageErrorInitialProps>>;
-
-type AppInitialProps = {
-  pageProps: PageErrorInitialProps;
-};
+export type ExcludeErrorProps<P> = Pick<
+  P,
+  Exclude<keyof P, keyof PageErrorInitialProps>
+>;
 
 /**
  * Small helper to generate errors object if needed
@@ -41,21 +51,54 @@ export const generatePageError = function<T extends Record<string, any>>(
  * https://spectrum.chat/next-js/general/error-handling-in-async-getinitialprops~99400c6c-0da8-4de5-aecd-2ecf122e8ad0
  * https://github.com/nuxt/nuxt.js/issues/895#issuecomment-308682972
  */
-const withError = function(ErrorComponent = ErrorPage) {
-  return function<P extends PageErrorInitialProps>(WrappedComponent: typeof NextApp) {
-    return class WithError extends React.Component<P & PageErrorInitialProps & AppProps> {
+const withErrorHoC = function(ErrorComponent = ErrorPage) {
+  // First function returned, the one allowing to pass the App component as a parameter
+  return function<P extends PageErrorInitialProps>(
+    AppComponent: typeof NextApp
+  ) {
+    // The actualy component working as a wrapper around _app
+    return class WithError extends React.Component<
+      P & PageErrorInitialProps & AppProps
+    > {
       public static getInitialProps = async (appContext: AppContext) => {
-        let appProps: AppInitialProps = { pageProps: {} };
+        let appProps: AppInitialProps;
 
-        if (WrappedComponent.getInitialProps) {
-          appProps = await WrappedComponent.getInitialProps(appContext);
+        if (AppComponent.getInitialProps) {
+          appProps = await AppComponent.getInitialProps(appContext);
+        } else {
+          throw new Error(
+            'AppComponent should have a getInitialProps method as described in https://github.com/martpie/next-with-error#witherrorerrorpageapp'
+          );
         }
 
         const { res } = appContext.ctx;
-        const { error } = appProps.pageProps;
+        const { pageProps } = appProps;
 
-        if (error && res) {
-          res.statusCode = error.statusCode;
+        if ('error' in pageProps && res) {
+          if (!('statusCode' in pageProps.error))
+            throw new Error(
+              'The error object should have a "statusCode" property.'
+            );
+
+          if (typeof pageProps.error.statusCode !== 'number')
+            throw new Error('The "statusCode" property should be a number.');
+
+          // We are in an user-defined error, let's fetch the Error component
+          // getInitialProps if needed, and merge them with the error object
+          let errorInitialProps: Record<string, any> = {};
+
+          if (ErrorComponent.getInitialProps) {
+            errorInitialProps = await ErrorComponent.getInitialProps(
+              appContext.ctx
+            );
+
+            appProps.pageProps = {
+              ...errorInitialProps,
+              ...appProps.pageProps
+            };
+          }
+
+          res.statusCode = pageProps.error.statusCode;
         }
 
         return appProps;
@@ -66,14 +109,19 @@ const withError = function(ErrorComponent = ErrorPage) {
         const { error } = pageProps;
 
         if (error && error.statusCode >= 400) {
-          const { statusCode, ...additionalErrorProps } = error;
-          return <ErrorComponent statusCode={error.statusCode} {...additionalErrorProps} />;
+          return (
+            <AppComponent
+              {...this.props}
+              Component={ErrorComponent}
+              pageProps={pageProps}
+            />
+          );
         }
 
-        return <WrappedComponent {...this.props} />;
+        return <AppComponent {...this.props} />;
       }
     };
   };
 };
 
-export default withError;
+export default withErrorHoC;


### PR DESCRIPTION
There are some breaking changes.

- Fix custom Error page not being wrapped by App
- Fix custom Error getInitialProps not being called
- Error object is not extracted to the root of the Error component props anymore
- Add some runtime errors in case the error object is invalid